### PR TITLE
Fix attraction type persistence

### DIFF
--- a/app/Http/Controllers/AdminAttractionController.php
+++ b/app/Http/Controllers/AdminAttractionController.php
@@ -35,6 +35,11 @@ public function create()
             'image' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:10240',
         ]);
 
+        // De attracties tabel bewaart de type naam als tekst. Haal daarom
+        // de naam op en voeg deze toe aan de validatie data.
+        $validated['type'] = AttractionType::findOrFail($validated['type_id'])->name;
+        unset($validated['type_id']);
+
         if ($request->hasFile('image')) {
             $manager = new ImageManager(new GdDriver());
             $image = $manager->read($request->file('image'));
@@ -73,6 +78,9 @@ public function edit(Attraction $attraction)
             'park_id' => 'required|exists:parks,id',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:10240',
         ]);
+
+        $validated['type'] = AttractionType::findOrFail($validated['type_id'])->name;
+        unset($validated['type_id']);
 
         if ($request->hasFile('image')) {
             if ($attraction->image_path) {


### PR DESCRIPTION
## Summary
- handle attraction type as text when storing or updating an attraction

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1a4a1548330be30089fea6851ab